### PR TITLE
Fixed a bug where query params without value were not handled properly

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-9 Fixed a bug where query params without value were changed to
+      params with empty value while encoding single param
+
 2.0.0:
   date: 2020-02-06
   new features:

--- a/encoder/index.js
+++ b/encoder/index.js
@@ -207,21 +207,21 @@ function encodeQueryParam (param) {
     }
 
     var key = param.key,
-        value = param.value;
+        value = param.value,
+        result;
 
-    if (typeof key !== STRING) {
-        key = E;
+    if (typeof key === STRING) {
+        result = _percentEncode(key, QUERY_ENCODE_SET);
+    }
+    else {
+        result = E;
     }
 
-    if (typeof value !== STRING) {
-        value = E;
+    if (typeof value === STRING) {
+        result += EQUALS + _percentEncode(value, QUERY_ENCODE_SET);
     }
 
-    if (key === E && value === E) {
-        return E;
-    }
-
-    return _percentEncode(key, QUERY_ENCODE_SET) + EQUALS + _percentEncode(value, QUERY_ENCODE_SET);
+    return result;
 }
 
 /**

--- a/test/unit/encoder/encoder.test.js
+++ b/test/unit/encoder/encoder.test.js
@@ -277,8 +277,24 @@ describe('encoder', function () {
             expect(encoder.encodeQueryParam({ value: 'bar' })).to.eql('=bar');
         });
 
+        it('should handle param object with null key', function () {
+            expect(encoder.encodeQueryParam({ key: null, value: 'bar' })).to.eql('=bar');
+        });
+
         it('should handle param object without value', function () {
-            expect(encoder.encodeQueryParam({ key: 'foo' })).to.eql('foo=');
+            expect(encoder.encodeQueryParam({ key: 'foo' })).to.eql('foo');
+        });
+
+        it('should handle param object with null value', function () {
+            expect(encoder.encodeQueryParam({ key: 'foo', value: null })).to.eql('foo');
+        });
+
+        it('should handle param object with empty value', function () {
+            expect(encoder.encodeQueryParam({ key: 'foo', value: '' })).to.eql('foo=');
+        });
+
+        it('should handle param object with empty key and empty value', function () {
+            expect(encoder.encodeQueryParam({ key: '', value: '' })).to.eql('=');
         });
 
         it('should return empty string for invalid param object', function () {
@@ -287,7 +303,7 @@ describe('encoder', function () {
         });
 
         it('should ignore non-string value in param object', function () {
-            expect(encoder.encodeQueryParam({ key: 'q', value: 123 })).to.eql('q=');
+            expect(encoder.encodeQueryParam({ key: 'q', value: 123 })).to.eql('q');
             expect(encoder.encodeQueryParam({ value: true })).to.eql('');
         });
 

--- a/test/unit/toNodeUrl.test.js
+++ b/test/unit/toNodeUrl.test.js
@@ -370,10 +370,19 @@ describe('.toNodeUrl', function () {
             it('should percent-encode SPACE, ("), (#), (&), (\'), (<), (=), and (>)', function () {
                 expect(toNodeUrl(new PostmanUrl({
                     host: 'example.com',
-                    query: [' ', '"', '#', '&', '\'', '<', '=', '>']
+                    query: [
+                        { key: ' ' },
+                        { key: '"' },
+                        { key: '#' },
+                        { key: '&' },
+                        { key: '\'' },
+                        { key: '<' },
+                        { key: '=' },
+                        { key: '>' }
+                    ]
                 }))).to.include({
-                    query: '%20=&%22=&%23=&%26=&%27=&%3C=&%3E=',
-                    search: '?%20=&%22=&%23=&%26=&%27=&%3C=&%3E='
+                    query: '%20&%22&%23&%26&%27&%3C&%3D&%3E',
+                    search: '?%20&%22&%23&%26&%27&%3C&%3D&%3E'
                 });
             });
 


### PR DESCRIPTION
It was converting query param without value to a param with empty value while encoding single param.
For example, `param = {key: 'foo'}` was encoded to `'foo='` but it should be encoded to `'foo'`. It is fixed in this change.