### PR TITLE
Handle domainToASCII in Electron v3

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -2,6 +2,9 @@ master:
   new features:
     - GH-11 Added an option to disable encoding on `toNodeUrl()`
   fixed bugs:
+    - >-
+      GH-12 Fixed a bug where Node.js native `url.domainToASCII` was not
+      working as expected in Electron v3
     - GH-10 Handle query parameters with empty key or value
     - >-
       GH-9 Fixed a bug where query params without value were changed to

--- a/encoder/index.js
+++ b/encoder/index.js
@@ -82,12 +82,23 @@ const url = require('url'),
      * @param {String} domain domain name
      * @returns {String} punycode encoded domain name
      */
-    domainToASCII = typeof url.domainToASCII === 'function' ?
-        // use faster internal method
-        url.domainToASCII :
+    domainToASCII = (function () {
+        var domainToASCII = url.domainToASCII;
+
+        // @note In Electron v3.1.8, the Node.js native url.domainToASCII
+        // doesn't work as expected. ¯\_(ツ)_/¯
+        // so, check if it convert's '😎' to 'xn--s28h' or not.
+        // @todo Remove this hack on Electron >= 4
+        /* istanbul ignore next */
+        if (typeof domainToASCII === 'function' && domainToASCII('😎') === 'xn--s28h') {
+            // use faster native method
+            return domainToASCII;
+        }
+
         // else, lazy load `punycode` dependency
         /* istanbul ignore next */
-        require('punycode').toASCII;
+        return require('punycode').toASCII;
+    }());
 
 /**
  * Returns the Punycode ASCII serialization of the domain.


### PR DESCRIPTION
Electron-Node has a bug in Electron v3 where the Node.js native  `url.domainToASCII` doesn't work as expected.