### PR TITLE
Removed `&` and `=` from QUERY_ENCODE_SET

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - GH-20 Removed `&` and `=` from QUERY_ENCODE_SET
+
 2.1.0:
   date: 2020-03-02
   new features:

--- a/encoder/encode-set.js
+++ b/encoder/encode-set.js
@@ -30,7 +30,7 @@
 const STRING = 'string',
     FUNCTION = 'function',
 
-    QUERY_ENCODE_CHARS = [' ', '"', '#', '&', '\'', '<', '=', '>'],
+    QUERY_ENCODE_CHARS = [' ', '"', '#', '\'', '<', '>'],
     FRAGMENT_EXTEND_CHARS = [' ', '"', '<', '>', '`'],
     PATH_EXTEND_CHARS = ['#', '?', '{', '}'],
     USERINFO_EXTEND_CHARS = ['/', ':', ';', '=', '@', '[', '\\', ']', '^', '|'];
@@ -321,11 +321,11 @@ var
 
     /**
      * The query percent-encode set is the C0 control percent-encode set and
-     * U+0020 SPACE, U+0022 ("), U+0023 (#), U+0026 (&), U+0027 ('), U+003C (<),
-     * U+003D (=), and U+003E (>).
+     * U+0020 SPACE, U+0022 ("), U+0023 (#), U+0027 ('), U+003C (<), and U+003E (>).
      *
      * @const
      * @type {EncodeSet}
+     * @see {@link https://url.spec.whatwg.org/#query-state}
      */
     QUERY_ENCODE_SET = new EncodeSet(QUERY_ENCODE_CHARS).seal();
 

--- a/encoder/index.js
+++ b/encoder/index.js
@@ -60,6 +60,9 @@ const url = require('url'),
     FRAGMENT_ENCODE_SET = encodeSet.FRAGMENT_ENCODE_SET,
     C0_CONTROL_ENCODE_SET = encodeSet.C0_CONTROL_ENCODE_SET,
 
+    PARAM_VALUE_ENCODE_SET = EncodeSet.extend(QUERY_ENCODE_SET, ['&']).seal(),
+    PARAM_KEY_ENCODE_SET = EncodeSet.extend(QUERY_ENCODE_SET, ['&', '=']).seal(),
+
     E = '',
     EQUALS = '=',
     AMPERSAND = '&',
@@ -199,8 +202,8 @@ function encodeFragment (fragment) {
  * Encodes single query parameter and returns as a string.
  *
  * @example
- * // returns 'param%20%22%23%26%27%3C%3D%3E'
- * encodeQueryParam('param "#&\'<=>')
+ * // returns 'param%20%22%23%27%3C%3E'
+ * encodeQueryParam('param "#\'<>')
  *
  * // returns 'foo=bar'
  * encodeQueryParam({ key: 'foo', value: 'bar' })
@@ -222,14 +225,14 @@ function encodeQueryParam (param) {
         result;
 
     if (typeof key === STRING) {
-        result = _percentEncode(key, QUERY_ENCODE_SET);
+        result = _percentEncode(key, PARAM_KEY_ENCODE_SET);
     }
     else {
         result = E;
     }
 
     if (typeof value === STRING) {
-        result += EQUALS + _percentEncode(value, QUERY_ENCODE_SET);
+        result += EQUALS + _percentEncode(value, PARAM_VALUE_ENCODE_SET);
     }
 
     return result;

--- a/index.js
+++ b/index.js
@@ -206,8 +206,8 @@ function toNodeUrl (url, disableEncoding) {
     hostname = url.getHost().toLowerCase();
 
     if (url.query && url.query.count()) {
-        queryParams = disableEncoding ? url.getQueryString({ ignoreDisabled: true }) :
-            encoder.encodeQueryParams(url.query.all());
+        queryParams = url.getQueryString({ ignoreDisabled: true });
+        queryParams = disableEncoding ? queryParams : encoder.encodeQueryParam(queryParams);
 
         // either all the params are disabled or a single param is like { key: '' } (http://localhost?)
         // in that case, query separator ? must be included in the raw URL.

--- a/test/unit/encode.test.js
+++ b/test/unit/encode.test.js
@@ -17,12 +17,12 @@ describe('.encode', function () {
         expect(encode(char)).to.equal(percentEncodeCharCode(127));
     });
 
-    it('should percent-encode SPACE, ("), (#), (&), (\'), (<), (=), and (>)', function () {
+    it('should percent-encode SPACE, ("), (#), (\'), (<), and (>)', function () {
         var i,
             char,
             encoded,
             chars = [],
-            expected = [' ', '"', '#', '&', '\'', '<', '=', '>'];
+            expected = [' ', '"', '#', '\'', '<', '>'];
 
         for (i = 32; i < 127; i++) {
             char = String.fromCharCode(i);

--- a/test/unit/encoder/constants.test.js
+++ b/test/unit/encoder/constants.test.js
@@ -136,10 +136,10 @@ describe('constants', function () {
             expect(doesExtends(encodeSet.C0_CONTROL_ENCODE_SET, SET)).to.be.true;
         });
 
-        it('should be extend by SPACE, ("), (#), (&), (\'), (<), (=), and (>)', function () {
+        it('should be extend by SPACE, ("), (#), (\'), (<), and (>)', function () {
             var i,
                 chars = [],
-                expected = [' ', '"', '#', '&', '\'', '<', '=', '>'];
+                expected = [' ', '"', '#', '\'', '<', '>'];
 
             for (i = 32; i < 127; i++) {
                 SET.has(i) && chars.push(String.fromCharCode(i));

--- a/test/unit/encoder/encoder.test.js
+++ b/test/unit/encoder/encoder.test.js
@@ -230,12 +230,12 @@ describe('encoder', function () {
             expect(encoder.encodeQueryParam(char)).to.equal(encoder.percentEncodeCharCode(127));
         });
 
-        it('should percent-encode SPACE, ("), (#), (&), (\'), (<), (=), and (>)', function () {
+        it('should percent-encode SPACE, ("), (#), (\'), (<), and (>)', function () {
             var i,
                 char,
                 encoded,
                 chars = [],
-                expected = [' ', '"', '#', '&', '\'', '<', '=', '>'];
+                expected = [' ', '"', '#', '\'', '<', '>'];
 
             for (i = 32; i < 127; i++) {
                 char = String.fromCharCode(i);
@@ -273,8 +273,48 @@ describe('encoder', function () {
             expect(encoder.encodeQueryParam({ key: 'q', value: '(🚀)' })).to.equal('q=(%F0%9F%9A%80)');
         });
 
+        it('should percent-encode SPACE, ("), (#), (&), (\'), (<), (=), and (>) in param key', function () {
+            var i,
+                char,
+                encoded,
+                chars = [],
+                expected = [' ', '"', '#', '&', '\'', '<', '=', '>'];
+
+            for (i = 32; i < 127; i++) {
+                char = String.fromCharCode(i);
+                encoded = encoder.encodeQueryParam({ key: char });
+
+                if (char !== encoded) {
+                    chars.push(char);
+                    expect(encoded).to.equal(encoder.percentEncodeCharCode(i));
+                }
+            }
+
+            expect(chars).to.have.all.members(expected);
+        });
+
+        it('should percent-encode SPACE, ("), (#), (&), (\'), (<), and (>) in param value', function () {
+            var i,
+                char,
+                encoded,
+                chars = [],
+                expected = [' ', '"', '#', '&', '\'', '<', '>'];
+
+            for (i = 32; i < 127; i++) {
+                char = String.fromCharCode(i);
+                encoded = encoder.encodeQueryParam({ value: char }).slice(1); // leading `=`
+
+                if (char !== encoded) {
+                    chars.push(char);
+                    expect(encoded).to.equal(encoder.percentEncodeCharCode(i));
+                }
+            }
+
+            expect(chars).to.have.all.members(expected);
+        });
+
         it('should handle param object without key', function () {
-            expect(encoder.encodeQueryParam({ value: 'bar' })).to.eql('=bar');
+            expect(encoder.encodeQueryParam({ value: 'bar&=#' })).to.eql('=bar%26=%23');
         });
 
         it('should handle param object with null key', function () {
@@ -282,7 +322,7 @@ describe('encoder', function () {
         });
 
         it('should handle param object without value', function () {
-            expect(encoder.encodeQueryParam({ key: 'foo' })).to.eql('foo');
+            expect(encoder.encodeQueryParam({ key: 'foo&=#' })).to.eql('foo%26%3D%23');
         });
 
         it('should handle param object with null value', function () {

--- a/test/unit/toNodeUrl.test.js
+++ b/test/unit/toNodeUrl.test.js
@@ -9,7 +9,7 @@ const fs = require('fs'),
 
 describe('.toNodeUrl', function () {
     it('should accept url string', function () {
-        expect(toNodeUrl('cooper@郵便屋さん.com:399/foo&bar/{baz}?q=("foo")#`hash`'))
+        expect(toNodeUrl('cooper@郵便屋さん.com:399/foo&bar/{baz}?q=("f=o&o")#`hash`'))
             .to.eql({
                 protocol: 'http:',
                 slashes: true,
@@ -18,11 +18,11 @@ describe('.toNodeUrl', function () {
                 port: '399',
                 hostname: 'xn--48jwgn17gdel797d.com',
                 hash: '#%60hash%60',
-                search: '?q=(%22foo%22)',
-                query: 'q=(%22foo%22)',
+                search: '?q=(%22f=o&o%22)',
+                query: 'q=(%22f=o&o%22)',
                 pathname: '/foo&bar/%7Bbaz%7D',
-                path: '/foo&bar/%7Bbaz%7D?q=(%22foo%22)',
-                href: 'http://cooper@xn--48jwgn17gdel797d.com:399/foo&bar/%7Bbaz%7D?q=(%22foo%22)#%60hash%60'
+                path: '/foo&bar/%7Bbaz%7D?q=(%22f=o&o%22)',
+                href: 'http://cooper@xn--48jwgn17gdel797d.com:399/foo&bar/%7Bbaz%7D?q=(%22f=o&o%22)#%60hash%60'
             });
     });
 


### PR DESCRIPTION
`&` and `=` are not reserved chars in query and should not be [encoded](https://url.spec.whatwg.org/#query-state). 