### PR TITLE
Parser: handle `file://` and `file:///` correctly

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+  fixed bugs:
+    - >-
+      GH-133 Fixed a bug where slashes in the `file` protocol are handled
+      incorrectly
+
 3.0.2:
   date: 2021-07-14
   fixed bugs:

--- a/test/unit/parser/parser.test.js
+++ b/test/unit/parser/parser.test.js
@@ -220,7 +220,7 @@ describe('parser', function () {
             });
         });
 
-        it('should handle handle protocol with backslashes', function () {
+        it('should handle protocol with backslashes', function () {
             expect(parser.parse('http:\\\\localhost')).to.deep.include({
                 raw: 'http:\\\\localhost',
                 protocol: 'http',
@@ -229,11 +229,11 @@ describe('parser', function () {
         });
 
         it('should handle extra slashes after protocol', function () {
-            expect(parser.parse('http:////localhost')).to.deep.include({
-                raw: 'http:////localhost',
+            expect(parser.parse('http:////localhost/foo')).to.deep.include({
+                raw: 'http:////localhost/foo',
                 protocol: 'http',
                 host: ['localhost'],
-                path: undefined
+                path: ['foo']
             });
         });
 
@@ -261,6 +261,33 @@ describe('parser', function () {
                 protocol: undefined,
                 host: ['localhost'],
                 path: ['foo']
+            });
+        });
+
+        it('should handle file://host/foo', function () {
+            expect(parser.parse('file://host/foo')).to.deep.include({
+                raw: 'file://host/foo',
+                protocol: 'file',
+                host: ['host'],
+                path: ['foo']
+            });
+        });
+
+        it('should handle file:///foo/bar', function () {
+            expect(parser.parse('file:///foo/bar')).to.deep.include({
+                raw: 'file:///foo/bar',
+                protocol: 'file',
+                host: undefined,
+                path: ['foo', 'bar']
+            });
+        });
+
+        it('should handle file://///foo/bar', function () {
+            expect(parser.parse('file://///foo/bar')).to.deep.include({
+                raw: 'file://///foo/bar',
+                protocol: 'file',
+                host: undefined,
+                path: ['foo', 'bar']
             });
         });
 

--- a/test/unit/toNodeUrl.test.js
+++ b/test/unit/toNodeUrl.test.js
@@ -749,5 +749,29 @@ describe('.toNodeUrl', function () {
                 href: 'https://example.com/foo/bar'
             });
         });
+
+        // Refer: https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?
+        it('should handle file://host/path and file:///path', function () {
+            expect(toNodeUrl('file://host/path')).to.include({
+                host: 'host',
+                hostname: 'host',
+                pathname: '/path',
+                href: 'file://host/path'
+            });
+
+            expect(toNodeUrl('file:///path')).to.include({
+                host: '',
+                hostname: '',
+                pathname: '/path',
+                href: 'file:///path'
+            });
+
+            expect(toNodeUrl('file:////foo/bar')).to.include({
+                host: '',
+                hostname: '',
+                pathname: '/foo/bar',
+                href: 'file:///foo/bar'
+            });
+        });
     });
 });


### PR DESCRIPTION
Context: https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?