### PR TITLE
feat(): percent encoder browser compat

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,8 @@
+3.0.8:
+  date: 2025-08-28
+  refactor:
+    - Refactor `percent-encode.js` to not use Buffer.from(), which is not available in the browser
+
 3.0.7:
   date: 2025-03-27
   fixed bugs:

--- a/encoder/percent-encode.js
+++ b/encoder/percent-encode.js
@@ -42,6 +42,23 @@ function isPreEncodedCharacter (byte) {
 }
 
 /**
+ * Converts a string to a UTF-8 byte array.
+ *
+ * @private
+ * @param {String} value The string to convert.
+ * @returns {Array<Number>} The UTF-8 byte array.
+ */
+function stringToBytes (value) {
+    // Use TextEncoder if available, which is the case in modern browsers and Node.js v11+.
+    if (typeof TextEncoder === 'function') {
+        return new TextEncoder().encode(value);
+    }
+
+    // Fallback for Node.js v10 and older environments.
+    return Buffer.from(value);
+}
+
+/**
  * Checks if character at given index in the buffer is already percent encoded or not.
  *
  * @private
@@ -91,7 +108,7 @@ function encode (value, encodeSet) {
         ii,
         charCode,
         encoded = E,
-        buffer = Buffer.from(value);
+        buffer = stringToBytes(value);
 
     for (i = 0, ii = buffer.length; i < ii; ++i) {
         // avoid double encoding

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-url-encoder",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -533,16 +533,6 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      }
-    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -563,7 +553,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -1032,9 +1023,9 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "combine-source-map": "~0.8.0",
         "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
         "safe-buffer": "^5.1.1",
         "through2": "^2.0.0",
         "umd": "^3.0.0"
@@ -1074,7 +1065,6 @@
       "integrity": "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
         "browser-resolve": "^2.0.0",
@@ -1096,6 +1086,7 @@
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
         "insert-module-globals": "^7.2.1",
+        "JSONStream": "^1.0.3",
         "labeled-stream-splicer": "^2.0.0",
         "mkdirp-classic": "^0.5.2",
         "module-deps": "^6.2.3",
@@ -3668,11 +3659,11 @@
       "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "acorn-node": "^1.5.2",
         "combine-source-map": "^0.8.0",
         "concat-stream": "^1.6.1",
         "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
         "path-is-absolute": "^1.0.1",
         "process": "~0.11.0",
         "through2": "^2.0.0",
@@ -4304,6 +4295,16 @@
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "karma": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
@@ -4790,7 +4791,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
       "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "marked": {
       "version": "2.0.7",
@@ -5092,7 +5094,6 @@
       "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "browser-resolve": "^2.0.0",
         "cached-path-relative": "^1.0.2",
         "concat-stream": "~1.6.0",
@@ -5100,6 +5101,7 @@
         "detective": "^5.2.0",
         "duplexer2": "^0.1.2",
         "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
         "parents": "^1.0.0",
         "readable-stream": "^2.0.2",
         "resolve": "^1.4.0",
@@ -6937,6 +6939,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -6984,15 +6995,6 @@
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -7756,7 +7758,8 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xmlcreate": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-url-encoder",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Implementation of the WHATWG URL Standard",
   "author": "Postman Inc.",
   "license": "Apache-2.0",

--- a/test/unit/encode.test.js
+++ b/test/unit/encode.test.js
@@ -1,58 +1,140 @@
 const expect = require('chai').expect,
-
     encode = require('../../').encode,
     percentEncodeCharCode = require('../../encoder').percentEncodeCharCode;
 
 describe('.encode', function () {
-    it('should percent-encode C0 control codes', function () {
-        var i,
-            char;
+    describe('with TextEncoder', function () {
+        it('should percent-encode C0 control codes', function () {
+            var i,
+                char;
 
-        for (i = 0; i < 32; i++) {
-            char = String.fromCharCode(i);
-            expect(encode(char)).to.equal(percentEncodeCharCode(i));
-        }
-
-        char = String.fromCharCode(127);
-        expect(encode(char)).to.equal(percentEncodeCharCode(127));
-    });
-
-    it('should percent-encode SPACE, ("), (#), (\'), (<), and (>)', function () {
-        var i,
-            char,
-            encoded,
-            chars = [],
-            expected = [' ', '"', '#', '\'', '<', '>'];
-
-        for (i = 32; i < 127; i++) {
-            char = String.fromCharCode(i);
-            encoded = encode(char);
-
-            if (char !== encoded) {
-                chars.push(char);
-                expect(encoded).to.equal(percentEncodeCharCode(i));
+            for (i = 0; i < 32; i++) {
+                char = String.fromCharCode(i);
+                expect(encode(char)).to.equal(percentEncodeCharCode(i));
             }
-        }
 
-        expect(chars).to.eql(expected);
+            char = String.fromCharCode(127);
+            expect(encode(char)).to.equal(percentEncodeCharCode(127));
+        });
+
+        it('should percent-encode SPACE, ("), (#), (\'), (<), and (>)', function () {
+            var i,
+                char,
+                encoded,
+                chars = [],
+                expected = [' ', '"', '#', '\'', '<', '>'];
+
+            for (i = 32; i < 127; i++) {
+                char = String.fromCharCode(i);
+                encoded = encode(char);
+
+                if (char !== encoded) {
+                    chars.push(char);
+                    expect(encoded).to.equal(percentEncodeCharCode(i));
+                }
+            }
+
+            expect(chars).to.eql(expected);
+        });
+
+        it('should percent-encode unicode characters', function () {
+            expect(encode('𝌆й你ス')).to.eql('%F0%9D%8C%86%D0%B9%E4%BD%A0%E3%82%B9');
+        });
+
+        it('should percent-encode 4-byte unicode characters', function () {
+            expect(encode('𝌆')).to.eql('%F0%9D%8C%86');
+        });
+
+        it('should handle unpaired surrogates', function () {
+            expect(encode('\uD800')).to.eql('%EF%BF%BD');
+        });
+
+        it('should not double encode characters', function () {
+            expect(encode('key:%F0%9F%8D%AA')).to.equal('key:%F0%9F%8D%AA');
+        });
+
+        it('should return empty string on invalid input types', function () {
+            expect(encode()).to.equal('');
+            expect(encode(null)).to.equal('');
+            expect(encode(undefined)).to.equal('');
+            expect(encode(NaN)).to.equal('');
+            expect(encode(true)).to.equal('');
+            expect(encode(1234)).to.equal('');
+            expect(encode(Function)).to.equal('');
+            expect(encode(['key', 'value'])).to.equal('');
+        });
     });
 
-    it('should percent-encode unicode characters', function () {
-        expect(encode('𝌆й你ス')).to.eql('%F0%9D%8C%86%D0%B9%E4%BD%A0%E3%82%B9');
-    });
+    describe('without TextEncoder', function () {
+        let oldTextEncoder;
 
-    it('should not double encode characters', function () {
-        expect(encode('key:%F0%9F%8D%AA')).to.equal('key:%F0%9F%8D%AA');
-    });
+        before(function () {
+            oldTextEncoder = global.TextEncoder;
+            global.TextEncoder = undefined;
+        });
 
-    it('should return empty string on invalid input types', function () {
-        expect(encode()).to.equal('');
-        expect(encode(null)).to.equal('');
-        expect(encode(undefined)).to.equal('');
-        expect(encode(NaN)).to.equal('');
-        expect(encode(true)).to.equal('');
-        expect(encode(1234)).to.equal('');
-        expect(encode(Function)).to.equal('');
-        expect(encode(['key', 'value'])).to.equal('');
+        after(function () {
+            global.TextEncoder = oldTextEncoder;
+        });
+
+        it('should percent-encode C0 control codes', function () {
+            var i,
+                char;
+
+            for (i = 0; i < 32; i++) {
+                char = String.fromCharCode(i);
+                expect(encode(char)).to.equal(percentEncodeCharCode(i));
+            }
+
+            char = String.fromCharCode(127);
+            expect(encode(char)).to.equal(percentEncodeCharCode(127));
+        });
+
+        it('should percent-encode SPACE, ("), (#), (\'), (<), and (>)', function () {
+            var i,
+                char,
+                encoded,
+                chars = [],
+                expected = [' ', '"', '#', '\'', '<', '>'];
+
+            for (i = 32; i < 127; i++) {
+                char = String.fromCharCode(i);
+                encoded = encode(char);
+
+                if (char !== encoded) {
+                    chars.push(char);
+                    expect(encoded).to.equal(percentEncodeCharCode(i));
+                }
+            }
+
+            expect(chars).to.eql(expected);
+        });
+
+        it('should percent-encode unicode characters', function () {
+            expect(encode('𝌆й你ス')).to.eql('%F0%9D%8C%86%D0%B9%E4%BD%A0%E3%82%B9');
+        });
+
+        it('should percent-encode 4-byte unicode characters', function () {
+            expect(encode('𝌆')).to.eql('%F0%9D%8C%86');
+        });
+
+        it('should handle unpaired surrogates', function () {
+            expect(encode('\uD800')).to.eql('%EF%BF%BD');
+        });
+
+        it('should not double encode characters', function () {
+            expect(encode('key:%F0%9F%8D%AA')).to.equal('key:%F0%9F%8D%AA');
+        });
+
+        it('should return empty string on invalid input types', function () {
+            expect(encode()).to.equal('');
+            expect(encode(null)).to.equal('');
+            expect(encode(undefined)).to.equal('');
+            expect(encode(NaN)).to.equal('');
+            expect(encode(true)).to.equal('');
+            expect(encode(1234)).to.equal('');
+            expect(encode(Function)).to.equal('');
+            expect(encode(['key', 'value'])).to.equal('');
+        });
     });
 });


### PR DESCRIPTION
This PR refactors the percent-encoding.js file to use `TextEncoder` when available (for example on browsers) and fallback to `Buffer.from()` when unavailable (Node 10).

This allows the file to be consumed in the browser without any Node polyfills